### PR TITLE
CYBL-994 4.5: add the 'always compute package url' patch

### DIFF
--- a/central_registry/4.5.json
+++ b/central_registry/4.5.json
@@ -181,6 +181,17 @@
       "patch_id": "45_agent_cluster_settings_path-d38e6a3892553bf17dafabf2b6969fcaee465e1ef8f1fe534393fd2ff7cfa0b4", 
       "patch_name": "45_agent_cluster_settings_path", 
       "supports_community": false
+    }, 
+    {
+      "patch_definition_path": "45_agent_config_package_url.json", 
+      "patch_description": "Agent config: always regenerate package_url.", 
+      "patch_files": [
+        "45_agent_config_package_url_cloudify_agent_installer_config_agent_config.py"
+      ], 
+      "patch_hash": "7fef1c700ef72fa82d36fe8d631b541596f06a2e0b8f31299d6aa6e6015b1521", 
+      "patch_id": "45_agent_config_package_url-7fef1c700ef72fa82d36fe8d631b541596f06a2e0b8f31299d6aa6e6015b1521", 
+      "patch_name": "45_agent_config_package_url", 
+      "supports_community": false
     }
   ]
 }

--- a/patch_files/45_agent_config_package_url.json
+++ b/patch_files/45_agent_config_package_url.json
@@ -1,0 +1,31 @@
+{
+    "affected_services": [
+        "cloudify-mgmtworker"
+    ], 
+    "community": false, 
+    "description": "Agent config: always regenerate package_url.", 
+    "manager_versions": [
+        "4.5"
+    ], 
+    "patch_version": "2.0.0", 
+    "patches": [
+        {
+            "destinations": [
+                "/opt/mgmtworker/env/lib/python2.7/site-packages/cloudify_agent/installer/config/agent_config.py"
+            ], 
+            "patch_file": "45_agent_config_package_url_cloudify_agent_installer_config_agent_config.py", 
+            "sha256sum": "33888e5763afee65f9471d2a62c9e2ff7ce26c8b0e63e5b169cfd05ca4a49528"
+        }
+    ], 
+    "premium": true, 
+    "sha256sums_after": {
+        "/opt/mgmtworker/env/lib/python2.7/site-packages/cloudify_agent/installer/config/agent_config.py": [
+            "f0fa93a1ca73033058719d2c447449fb6538acf5620edac0278c492419be7447"
+        ]
+    }, 
+    "sha256sums_before": {
+        "/opt/mgmtworker/env/lib/python2.7/site-packages/cloudify_agent/installer/config/agent_config.py": [
+            "cad4c6a629e5bd6936d871e4ce97ffaed7f3eaa4efdf8adb7bc5423be1431e1c"
+        ]
+    }
+}

--- a/patch_files/patches/45_agent_config_package_url_cloudify_agent_installer_config_agent_config.py
+++ b/patch_files/patches/45_agent_config_package_url_cloudify_agent_installer_config_agent_config.py
@@ -1,0 +1,14 @@
+diff --git a/cloudify_agent/installer/config/agent_config.py b/cloudify_agent/installer/config/agent_config.py
+index 881b58f..a0c5913 100644
+--- a/cloudify_agent/installer/config/agent_config.py
++++ b/cloudify_agent/installer/config/agent_config.py
+@@ -361,9 +361,6 @@ class CloudifyAgentConfig(dict):
+                 cloudify_utils.get_broker_ssl_cert_path()
+ 
+     def _set_package_url(self, runner):
+-        if self.get('package_url'):
+-            return
+-
+         agent_package_name = None
+ 
+         if self.is_windows:


### PR DESCRIPTION
do not skip recomputing package_url if it is already set

it has to be always computed so that it is changed eg. in case of a failover
source commit is https://github.com/cloudify-cosmo/cloudify-agent/commit/9e0ab5cb306e15d6c503d520bb90922b0bb3573b